### PR TITLE
Fix undefined output on WSDL getOperationData

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4465,8 +4465,12 @@ class nusoap_server extends nusoap_base
             $this->debug('methodname: ' . $this->methodname . ' methodURI: ' . $this->methodURI);
 
             // get/set custom response tag name
-            $outputMessage = $this->wsdl->getOperationData($this->methodname)['output']['message'];
-            $this->responseTagName = $outputMessage;
+            $opData = $this->wsdl->getOperationData($this->methodname);
+	    if (!isset($opData['output']['name'])) {
+		$this->debug('No output name in WSDL for operation ' . $this->methodname);
+		$this->setError('Operation ' . $this->methodname . ' not present in WSDL');
+		return false;
+	    }
             $this->debug('responseTagName: ' . $this->responseTagName . ' methodURI: ' . $this->methodURI);
 
             $this->debug('calling parser->get_soapbody()');


### PR DESCRIPTION
This pull request includes a change to the `parseRequest` function in the `src/nusoap.php` file. The change enhances error handling by checking for the presence of an output name in the WSDL operation data and setting an error if it is not found.
