### PR TITLE
check if ['SERVER_NAME'] is set

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4652,7 +4652,7 @@ class nusoap_server extends nusoap_base
     {
         global $HTTP_SERVER_VARS;
 
-        if (isset($_SERVER)) {
+        if (isset($_SERVER['SERVER_NAME'])) {
             $SERVER_NAME = $_SERVER['SERVER_NAME'];
             $SERVER_PORT = $_SERVER['SERVER_PORT'];
             $SCRIPT_NAME = $_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
When running from CLI (eg for tests), ['SERVER_NAME'] is not set. Check its presence to avoid missing array key