### PR TITLE
revert commit be63630

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4463,8 +4463,9 @@ class nusoap_server extends nusoap_base
 
             // get/set custom response tag name
             $opData = $this->wsdl->getOperationData($this->methodname);
-            $outputMessage = $this->wsdl->getOperationData($this->methodname)['output']['message'];
-            $this->responseTagName = $outputMessage;
+            if ($message = $opData['output']['message']) {
+                $this->responseTagName = $message;
+            }
             $this->debug('responseTagName: ' . $this->responseTagName . ' methodURI: ' . $this->methodURI);
 
             $this->debug('calling parser->get_soapbody()');

--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4463,11 +4463,8 @@ class nusoap_server extends nusoap_base
 
             // get/set custom response tag name
             $opData = $this->wsdl->getOperationData($this->methodname);
-	    if (!isset($opData['output']['name'])) {
-		$this->debug('No output name in WSDL for operation ' . $this->methodname);
-		$this->setError('Operation ' . $this->methodname . ' not present in WSDL');
-		return false;
-	    }
+            $outputMessage = $this->wsdl->getOperationData($this->methodname)['output']['message'];
+            $this->responseTagName = $outputMessage;
             $this->debug('responseTagName: ' . $this->responseTagName . ' methodURI: ' . $this->methodURI);
 
             $this->debug('calling parser->get_soapbody()');


### PR DESCRIPTION
Reverts https://github.com/contributte/nusoap/commit/be63630028ac0405caf16a03de837a1f1e4a78eb

`$opData['output']['name']` is undefined, which causes the function to return too early. On top of that, `responseTagName` was no longer being set.

Comment on original issue: https://github.com/contributte/nusoap/issues/123#issuecomment-2665318138