### PR TITLE
fix: Handle warning for undefined output message

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4463,9 +4463,7 @@ class nusoap_server extends nusoap_base
 
             // get/set custom response tag name
             $opData = $this->wsdl->getOperationData($this->methodname);
-            if ($message = $opData['output']['message']) {
-                $this->responseTagName = $message;
-            }
+            $this->responseTagName = isset($opData['output']['message']) ? $opData['output']['message'] : '';
             $this->debug('responseTagName: ' . $this->responseTagName . ' methodURI: ' . $this->methodURI);
 
             $this->debug('calling parser->get_soapbody()');


### PR DESCRIPTION
The `if ($message = $opData['output']['message'])` doesn't resolve the issue with the warning: 
> Undefined array key "output".

The fix should resolve the problem.

P.S.:
It is not a good practice to set values in an "if" condition.