### PR TITLE
fix PHP 8.5 deprecation warnings

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -1263,7 +1263,7 @@ class nusoap_xmlschema extends nusoap_base
                 $this->setError($errstr);
             }
 
-            xml_parser_free($this->parser);
+            (PHP_VERSION_ID < 80000) && xml_parser_free($this->parser);
             unset($this->parser);
         } else {
             $this->debug('no xml passed to parseString()!!');
@@ -5010,12 +5010,12 @@ class wsdl extends nusoap_base
             $this->debug($errstr);
             $this->debug("XML payload:\n" . $wsdl_string);
             $this->setError($errstr);
-            xml_parser_free($this->parser);
+            (PHP_VERSION_ID < 80000) && xml_parser_free($this->parser);
             unset($this->parser);
             return false;
         }
         // free the parser
-        xml_parser_free($this->parser);
+        (PHP_VERSION_ID < 80000) && xml_parser_free($this->parser);
         unset($this->parser);
         $this->debug('Parsing WSDL done');
         // catch wsdl parse errors
@@ -6913,7 +6913,7 @@ class nusoap_parser extends nusoap_base
                     }
                 }
             }
-            xml_parser_free($this->parser);
+            (PHP_VERSION_ID < 80000) && xml_parser_free($this->parser);
             unset($this->parser);
         } else {
             $this->debug('xml was empty, didn\'t parse!');
@@ -7278,13 +7278,13 @@ class nusoap_parser extends nusoap_base
             return (int) $value;
         }
         if ($type == 'float' || $type == 'double' || $type == 'decimal') {
-            return (double) $value;
+            return (float) $value;
         }
         if ($type == 'boolean') {
             if (strtolower($value) == 'false' || strtolower($value) == 'f') {
                 return false;
             }
-            return (boolean) $value;
+            return (bool) $value;
         }
         if ($type == 'base64' || $type == 'base64Binary') {
             $this->debug('Decode base64 value');


### PR DESCRIPTION
RuntimeException: Non-canonical cast (double) is deprecated, use the (float) cast instead on line 7281 in file /path/to/econea/nusoap/src/nusoap.php
RuntimeException: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead on line 7287 in file /path/to/econea/nusoap/src/nusoap.php
RuntimeException: Function xml_parser_free() is deprecated since 8.5, as it has no effect since PHP 8.0 on line 6916 in file /path/to/econea/nusoap/src/nusoap.php