### PR TITLE
Lint for PHP 5.6 to 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,70 @@ on:
     branches: [ "*" ]
 
 jobs:
+  lint56:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "5.6"
+
+  lint70:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "7.0"
+
+  lint71:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "7.1"
+
+  lint72:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "7.2"
+
+  lint73:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "7.3"
+
+  lint74:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "7.4"
+
+  lint80:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "8.0"
+
+  lint81:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "8.1"
+
   lint82:
     name: "Linter"
     uses: contributte/.github/.github/workflows/php.yml@v1
@@ -15,10 +79,26 @@ jobs:
       run: "vendor/bin/parallel-lint src"
       php: "8.2"
 
-  lint56:
+  lint83:
     name: "Linter"
     uses: contributte/.github/.github/workflows/php.yml@v1
     with:
       name: "Linter"
       run: "vendor/bin/parallel-lint src"
-      php: "5.6"
+      php: "8.3"
+
+  lint84:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "8.4"
+
+  lint85:
+    name: "Linter"
+    uses: contributte/.github/.github/workflows/php.yml@v1
+    with:
+      name: "Linter"
+      run: "vendor/bin/parallel-lint src"
+      php: "8.5"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NuSOAP is a rewrite of SOAPx4, provided by NuSphere and Dietrich Ayala. It is a 
 
 ## Info
 
-- Supported PHP: [5.4 - 8.2](https://packagist.org/packages/econea/nusoap)
+- Supported PHP: [5.6 - 8.5](https://packagist.org/packages/econea/nusoap)
 - Official project: https://sourceforge.net/projects/nusoap/
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "econea/nusoap",
   "type": "library",
-  "description": "Fixed NuSOAP for PHP 5.4 - 8.2",
+  "description": "Fixed NuSOAP for PHP 5.6 - 8.5",
   "keywords": ["soap","nusoap","php","http","xml","transport","client"],
   "license": "LGPL-2.1-or-later",
   "homepage": "https://github.com/pwnlabs/nusoap",
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.6",
     "ext-xml": "*",
     "ext-curl": "*",
     "ext-json": "*",


### PR DESCRIPTION
- Extend lint.yml with jobs for all PHP versions: 5.6, 7.0-7.4, 8.0-8.5
- Update README.md to reflect supported PHP 5.6-8.5
- Update composer.json description and PHP requirement to >=5.6