### PR TITLE
Fix PHP 8 compatibility with curl_close

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -3191,12 +3191,16 @@ class soap_transport_http extends nusoap_base
                 }
                 $this->debug($err);
                 $this->setError($err);
-                curl_close($this->ch);
+                if (PHP_VERSION_ID < 80000) {
+                    curl_close($this->ch);
+                }
                 return false;
             }
             // close curl
             $this->debug('No cURL error, closing cURL');
-            curl_close($this->ch);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($this->ch);
+            }
 
             // try removing skippable headers
             $savedata = $data;


### PR DESCRIPTION
curl_close() has no effect since PHP 8.0 and is deprecated in PHP 8.5. Wrap the calls with a PHP version check to maintain backward compatibility while eliminating deprecation warnings on newer PHP versions.

Fixes #140