### PR TITLE
PHP Deprecated: Creation of dynamic property wsdl::$schemaTargetNamespace is deprecated

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4790,6 +4790,8 @@ class wsdl extends nusoap_base
     /** @var mixed */
     var $serviceName;
     var $wsdl_info;
+    /** @var string */
+    var $schemaTargetNamespace = '';
 
     /**
      * constructor

--- a/tests/Cases/WsdlTest.phpt
+++ b/tests/Cases/WsdlTest.phpt
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+// Test wsdl instantiation
+Toolkit::test(static function (): void {
+	$wsdl = new wsdl();
+
+	Assert::type('wsdl', $wsdl);
+});
+
+// Test schemaTargetNamespace property exists and is initialized (fix for issue #135)
+// This prevents PHP 8.2+ deprecation warning: "Creation of dynamic property wsdl::$schemaTargetNamespace is deprecated"
+Toolkit::test(static function (): void {
+	$wsdl = new wsdl();
+
+	// Property should exist and be initialized to empty string
+	Assert::true(property_exists($wsdl, 'schemaTargetNamespace'));
+	Assert::same('', $wsdl->schemaTargetNamespace);
+
+	// Should be able to set the property without triggering deprecation warning
+	$wsdl->schemaTargetNamespace = 'http://example.com/schema';
+	Assert::same('http://example.com/schema', $wsdl->schemaTargetNamespace);
+});
+
+// Test wsdl default properties
+Toolkit::test(static function (): void {
+	$wsdl = new wsdl();
+
+	Assert::same([], $wsdl->schemas);
+	Assert::same([], $wsdl->messages);
+	Assert::same([], $wsdl->portTypes);
+	Assert::same([], $wsdl->bindings);
+	Assert::same([], $wsdl->ports);
+	Assert::same('', $wsdl->status);
+	Assert::same('', $wsdl->endpoint);
+});
+
+// Test wsdl inherits from nusoap_base
+Toolkit::test(static function (): void {
+	$wsdl = new wsdl();
+
+	Assert::type('nusoap_base', $wsdl);
+	Assert::same('NuSOAP', $wsdl->title);
+});


### PR DESCRIPTION
Add explicit declaration of $schemaTargetNamespace property to the wsdl class to prevent PHP 8.2+ deprecation warning about dynamic property creation. This addresses issue #135.

Also adds WsdlTest.phpt with test cases for the wsdl class including verification that the schemaTargetNamespace property is properly declared.