### PR TITLE
Resolve #76 

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -617,9 +617,9 @@ class nusoap_base
                             $array_typename = 'unnamed_struct_use_soapval';
                         } else {
                             // if type is prefixed, create type prefix
-                            if ($tt_ns != '' && $tt_ns == $this->namespaces['xsd']) {
+                            if (isset($tt_ns) && $tt_ns != '' && $tt_ns == $this->namespaces['xsd']) {
                                 $array_typename = 'xsd:' . $tt;
-                            } elseif ($tt_ns) {
+                            } elseif (isset($tt_ns) && $tt_ns) {
                                 $tt_prefix = 'ns' . rand(1000, 9999);
                                 $array_typename = "$tt_prefix:$tt";
                                 $xmlns .= " xmlns:$tt_prefix=\"$tt_ns\"";


### PR DESCRIPTION
Add isset() checks before accessing $tt_ns variable to prevent "Undefined variable: tt_ns" ErrorException on PHP with strict error reporting.

Fixes #76