### PR TITLE
Resolve #66

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -3741,16 +3741,12 @@ class nusoap_server extends nusoap_base
         parent::__construct();
         // turn on debugging?
         global $debug;
-        global $HTTP_SERVER_VARS;
 
         if (isset($_SERVER)) {
             $this->debug("_SERVER is defined:");
             $this->appendDebug($this->varDump($_SERVER));
-        } elseif (isset($HTTP_SERVER_VARS)) {
-            $this->debug("HTTP_SERVER_VARS is defined:");
-            $this->appendDebug($this->varDump($HTTP_SERVER_VARS));
         } else {
-            $this->debug("Neither _SERVER nor HTTP_SERVER_VARS is defined.");
+            $this->debug("_SERVER is not defined.");
         }
 
         if (isset($debug)) {
@@ -3760,15 +3756,7 @@ class nusoap_server extends nusoap_base
             $qs = explode('&', $_SERVER['QUERY_STRING']);
             foreach ($qs as $v) {
                 if (substr($v, 0, 6) == 'debug=') {
-                    $this->debug("In nusoap_server, set debug_flag=" . substr($v, 6) . " based on query string #1");
-                    $this->debug_flag = substr($v, 6);
-                }
-            }
-        } elseif (isset($HTTP_SERVER_VARS['QUERY_STRING'])) {
-            $qs = explode('&', $HTTP_SERVER_VARS['QUERY_STRING']);
-            foreach ($qs as $v) {
-                if (substr($v, 0, 6) == 'debug=') {
-                    $this->debug("In nusoap_server, set debug_flag=" . substr($v, 6) . " based on query string #2");
+                    $this->debug("In nusoap_server, set debug_flag=" . substr($v, 6) . " based on query string");
                     $this->debug_flag = substr($v, 6);
                 }
             }
@@ -3802,23 +3790,8 @@ class nusoap_server extends nusoap_base
      */
     function service($data)
     {
-        global $HTTP_SERVER_VARS;
-
-        if (isset($_SERVER['REQUEST_METHOD'])) {
-            $rm = $_SERVER['REQUEST_METHOD'];
-        } elseif (isset($HTTP_SERVER_VARS['REQUEST_METHOD'])) {
-            $rm = $HTTP_SERVER_VARS['REQUEST_METHOD'];
-        } else {
-            $rm = '';
-        }
-
-        if (isset($_SERVER['QUERY_STRING'])) {
-            $qs = $_SERVER['QUERY_STRING'];
-        } elseif (isset($HTTP_SERVER_VARS['QUERY_STRING'])) {
-            $qs = $HTTP_SERVER_VARS['QUERY_STRING'];
-        } else {
-            $qs = '';
-        }
+        $rm = $_SERVER['REQUEST_METHOD'] ?? '';
+        $qs = $_SERVER['QUERY_STRING'] ?? '';
         $this->debug("In service, request method=$rm query string=$qs strlen(\$data)=" . strlen($data));
 
         if ($rm == 'POST') {
@@ -3881,8 +3854,6 @@ class nusoap_server extends nusoap_base
      */
     function parse_http_headers()
     {
-        global $HTTP_SERVER_VARS;
-
         $this->request = '';
         $this->SOAPAction = '';
         if (function_exists('getallheaders')) {
@@ -3948,42 +3919,6 @@ class nusoap_server extends nusoap_base
                     $this->request .= "$k: $v\r\n";
                     $this->debug("$k: $v");
                 }
-            }
-        } elseif (is_array($HTTP_SERVER_VARS)) {
-            $this->debug("In parse_http_headers, use HTTP_SERVER_VARS");
-            foreach ($HTTP_SERVER_VARS as $k => $v) {
-                if (substr($k, 0, 5) == 'HTTP_') {
-                    $k = str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($k, 5))));
-                    $k = strtolower(substr($k, 5));
-                } else {
-                    $k = str_replace(' ', '-', strtolower(str_replace('_', ' ', $k)));
-                    $k = strtolower($k);
-                }
-                if ($k == 'soapaction') {
-                    // get SOAPAction header
-                    $k = 'SOAPAction';
-                    $v = str_replace('"', '', $v);
-                    $v = str_replace('\\', '', $v);
-                    $this->SOAPAction = $v;
-                } elseif ($k == 'content-type') {
-                    // get the character encoding of the incoming request
-                    if (strpos($v, '=')) {
-                        $enc = substr(strstr($v, '='), 1);
-                        $enc = str_replace('"', '', $enc);
-                        $enc = str_replace('\\', '', $enc);
-                        if (preg_match('/^(ISO-8859-1|US-ASCII|UTF-8)$/i', $enc)) {
-                            $this->xml_encoding = strtoupper($enc);
-                        } else {
-                            $this->xml_encoding = 'US-ASCII';
-                        }
-                    } else {
-                        // should be US-ASCII for HTTP 1.0 or ISO-8859-1 for HTTP 1.1
-                        $this->xml_encoding = 'ISO-8859-1';
-                    }
-                }
-                $this->headers[$k] = $v;
-                $this->request .= "$k: $v\r\n";
-                $this->debug("$k: $v");
             }
         } else {
             $this->debug("In parse_http_headers, HTTP headers not accessible");
@@ -4551,8 +4486,6 @@ class nusoap_server extends nusoap_base
      */
     function register($name, $in = array(), $out = array(), $namespace = false, $soapaction = false, $style = false, $use = false, $documentation = '', $encodingStyle = '', $customResponseTagName = '')
     {
-        global $HTTP_SERVER_VARS;
-
         if ($this->externalWSDLURL) {
             die('You cannot bind to an external WSDL file, and register methods outside of it! Please choose either WSDL or no WSDL.');
         }
@@ -4569,13 +4502,9 @@ class nusoap_server extends nusoap_base
             if (isset($_SERVER)) {
                 $SERVER_NAME = $_SERVER['SERVER_NAME'];
                 $SCRIPT_NAME = $_SERVER['SCRIPT_NAME'];
-                $HTTPS = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : (isset($HTTP_SERVER_VARS['HTTPS']) ? $HTTP_SERVER_VARS['HTTPS'] : 'off');
-            } elseif (isset($HTTP_SERVER_VARS)) {
-                $SERVER_NAME = $HTTP_SERVER_VARS['SERVER_NAME'];
-                $SCRIPT_NAME = $HTTP_SERVER_VARS['SCRIPT_NAME'];
-                $HTTPS = isset($HTTP_SERVER_VARS['HTTPS']) ? $HTTP_SERVER_VARS['HTTPS'] : 'off';
+                $HTTPS = $_SERVER['HTTPS'] ?? 'off';
             } else {
-                $this->setError("Neither _SERVER nor HTTP_SERVER_VARS is available");
+                $this->setError("_SERVER is not available");
                 $HTTPS = '';
                 $SERVER_NAME = '';
                 $SCRIPT_NAME = '';
@@ -4647,20 +4576,13 @@ class nusoap_server extends nusoap_base
      */
     function configureWSDL($serviceName, $namespace = false, $endpoint = false, $style = 'rpc', $transport = 'http://schemas.xmlsoap.org/soap/http', $schemaTargetNamespace = false)
     {
-        global $HTTP_SERVER_VARS;
-
         if (isset($_SERVER['SERVER_NAME'])) {
             $SERVER_NAME = $_SERVER['SERVER_NAME'];
             $SERVER_PORT = $_SERVER['SERVER_PORT'];
             $SCRIPT_NAME = $_SERVER['SCRIPT_NAME'];
-            $HTTPS = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : (isset($HTTP_SERVER_VARS['HTTPS']) ? $HTTP_SERVER_VARS['HTTPS'] : 'off');
-        } elseif (isset($HTTP_SERVER_VARS)) {
-            $SERVER_NAME = $HTTP_SERVER_VARS['SERVER_NAME'];
-            $SERVER_PORT = $HTTP_SERVER_VARS['SERVER_PORT'];
-            $SCRIPT_NAME = $HTTP_SERVER_VARS['SCRIPT_NAME'];
-            $HTTPS = isset($HTTP_SERVER_VARS['HTTPS']) ? $HTTP_SERVER_VARS['HTTPS'] : 'off';
+            $HTTPS = $_SERVER['HTTPS'] ?? 'off';
         } else {
-            $this->setError("Neither _SERVER nor HTTP_SERVER_VARS is available");
+            $this->setError("_SERVER is not available");
             $SERVER_PORT = '';
             $SERVER_NAME = '';
             $SCRIPT_NAME = '';
@@ -5510,16 +5432,7 @@ class wsdl extends nusoap_base
      */
     function webDescription()
     {
-        global $HTTP_SERVER_VARS;
-
-        if (isset($_SERVER)) {
-            $PHP_SELF = $_SERVER['PHP_SELF'];
-        } elseif (isset($HTTP_SERVER_VARS)) {
-            $PHP_SELF = $HTTP_SERVER_VARS['PHP_SELF'];
-        } else {
-            $this->setError("Neither _SERVER nor HTTP_SERVER_VARS is available");
-            $PHP_SELF = '';
-        }
+        $PHP_SELF = $_SERVER['PHP_SELF'] ?? '';
 
         $b = '<!DOCTYPE html>
 		<html><head><title>NuSOAP: ' . $this->serviceName . '</title>


### PR DESCRIPTION
$HTTP_SERVER_VARS was deprecated in PHP 5.3 and removed in PHP 5.4. Replace all usages with $_SERVER superglobal and simplify the code by removing the unnecessary fallback branches.

Fixes #66