### PR TITLE
Add PHP 8.5 to CI

### DIFF
--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -16,4 +16,4 @@ jobs:
     uses: contributte/.github/.github/workflows/codesniffer.yml@master
     continue-on-error: true
     with:
-      php: "8.3"
+      php: "8.5"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,5 +15,5 @@ jobs:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     with:
-      php: "8.3"
+      php: "8.5"
     secrets: inherit

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,4 +16,4 @@ jobs:
     uses: contributte/.github/.github/workflows/phpstan.yml@master
     continue-on-error: true
     with:
-      php: "8.3"
+      php: "8.5"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,12 @@ on:
     - cron: "0 8 * * 1"
 
 jobs:
+  test85:
+    name: "Nette Tester"
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
+    with:
+      php: "8.5"
+
   test84:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester.yml@master


### PR DESCRIPTION
## Summary
- add a dedicated Nette Tester job for PHP 8.5 in the main test workflow
- switch the standalone PHPStan, CodeSniffer, and coverage workflows to run on PHP 8.5
- keep existing lower and compatibility test coverage intact for supported versions