### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.5"
-    secrets: inherit


### PR DESCRIPTION
## What changed
- added `secrets: inherit` to the reusable coverage workflow caller in `.github/workflows/coverage.yml`

## Why
- allows the called coverage workflow to receive the repository secrets it needs as part of the issue 74 rollout
- relates to contributte/contributte#74