### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.5"
-    secrets: inherit


### PR DESCRIPTION
## What changed
- Added `secrets: inherit` to the reusable coverage workflow caller.

## Why
- Ensures the reusable coverage workflow receives required secrets during the issue #74 rollout.

Refs: contributte/contributte#74